### PR TITLE
Set drawFlag after sprite iteration

### DIFF
--- a/scripts/chip8.js
+++ b/scripts/chip8.js
@@ -428,8 +428,8 @@ var Chip8 = function () {
                          }
                          spr <<= 1;
                      }
-                     this.drawFlag = true;
                  }
+                 this.drawFlag = true;
 
                  break;
 


### PR DESCRIPTION
There's no reason to set the `drawFlag` to `true` on every single iteration of the sprite loop. Just set it at the end.
